### PR TITLE
Bump API version

### DIFF
--- a/smssluzbacz_api/lite.py
+++ b/smssluzbacz_api/lite.py
@@ -21,8 +21,8 @@ class SmsGateApi(object):
     with no advanced options and operations.
 
     """
-    URL = 'http://smsgateapi.sluzba.cz/apilite20/sms'
-    URL_SSL = 'https://smsgateapi.sluzba.cz/apilite20/sms'
+    URL = 'http://smsgateapi.sluzba.cz/apilite30/sms'
+    URL_SSL = 'https://smsgateapi.sluzba.cz/apilite30/sms'
 
     def __init__(self, login, password, timeout=2, use_ssl=True):
         """Initializes SmsGateApi class.

--- a/smssluzbacz_api/post.py
+++ b/smssluzbacz_api/post.py
@@ -20,8 +20,8 @@ class SmsGateApi(object):
     """
 
     ACTION_SEND = 'send'
-    URL = 'http://smsgateapi.sluzba.cz/apipost20/sms'
-    URL_SSL = 'https://smsgateapi.sluzba.cz/apipost20/sms'
+    URL = 'http://smsgateapi.sluzba.cz/apipost30/sms'
+    URL_SSL = 'https://smsgateapi.sluzba.cz/apipost30/sms'
 
     def __init__(self, login, password, timeout=2, use_ssl=True):
         """Initializes SmsGateApi class.


### PR DESCRIPTION
API version 3.0 seems to be defined the same way as 2.0, at least from
the point of sending SMS. Integration tests work.